### PR TITLE
fix unfortunate typos (fartmasker -> farmtasker)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -508,7 +508,7 @@ NOTE:
                   GNU LESSER GENERAL PUBLIC LICENSE
                        Version 2.1, February 1999
 
-fartmasker.au a marketplace website for local farmers in Tasmania.
+farmtasker.au a marketplace website for local farmers in Tasmania.
 Copyright (C) 2024 Dmytro Serdiukov & FARMTASKER PTY LTD
 
 NOTE: All images, logos, and branding are the exclusive property of FARMTASKER PTY LTD and are not covered by the open-source license.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Tests are located in end2end/tests directory.
                   GNU LESSER GENERAL PUBLIC LICENSE
                        Version 2.1, February 1999
 
-fartmasker.au a marketplace website for local farmers in Tasmania.
+farmtasker.au a marketplace website for local farmers in Tasmania.
 Copyright (C) 2024 Dmytro Serdiukov & FARMTASKER PTY LTD
 
 NOTE: All images, logos, and branding are the exclusive property of FARMTASKER PTY LTD and are not covered by the open-source license.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 //                   GNU LESSER GENERAL PUBLIC LICENSE
 //                        Version 2.1, February 1999
 //
-// fartmasker.au a marketplace website for local farmers in Tasmania.
+// farmtasker.au a marketplace website for local farmers in Tasmania.
 // Copyright (C) 2024 Dmytro Serdiukov & FARMTASKER PTY LTD
 //
 // NOTE: All images, logos, and branding are the exclusive property of FARMTASKER PTY LTD and are not covered by the open-source license.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 //                   GNU LESSER GENERAL PUBLIC LICENSE
 //                        Version 2.1, February 1999
 //
-// fartmasker.au a marketplace website for local farmers in Tasmania.
+// farmtasker.au a marketplace website for local farmers in Tasmania.
 // Copyright (C) 2024 Dmytro Serdiukov & FARMTASKER PTY LTD
 //
 // NOTE: All images, logos, and branding are the exclusive property of FARMTASKER PTY LTD and are not covered by the open-source license.


### PR DESCRIPTION
There were a few instances where the application was called `fartmasker` when it clearly should be `farmtasker`. This is unfortunate (yet hilarious). It has been fixed 😉 