### PR TITLE
docs: log failed attempts to fetch Stripe and async-stripe docs

### DIFF
--- a/docs/stripe-docs-fetch.log
+++ b/docs/stripe-docs-fetch.log
@@ -1,0 +1,16 @@
+Attempted to fetch Stripe API docs (products/prices) and async-stripe docs via curl.
+
+Command:
+  curl -L https://stripe.com/docs/api/prices/object | rg -n "immutable|cannot|update|amount|currency" | head -n 20
+Result:
+  curl: (56) CONNECT tunnel failed, response 403
+
+Command:
+  curl -L -A "Mozilla/5.0" https://stripe.com/docs/api/prices/object | rg -n "immutable|cannot|update|amount|currency" | head -n 20
+Result:
+  curl: (56) CONNECT tunnel failed, response 403
+
+Command:
+  curl -L https://docs.rs/async-stripe/latest/async_stripe/ | head -n 20
+Result:
+  curl: (56) CONNECT tunnel failed, response 403


### PR DESCRIPTION
### Motivation
- Record that attempts to fetch Stripe API and `async-stripe` documentation from this environment failed due to blocked network requests (HTTP 403), so the failure is traceable.

### Description
- Add `docs/stripe-docs-fetch.log` which contains the attempted `curl` commands (e.g. `curl -L https://stripe.com/docs/api/prices/object` and `curl -L https://docs.rs/async-stripe/latest/async_stripe/`) and the observed `curl: (56) CONNECT tunnel failed, response 403` results.

### Testing
- Not applicable: this is a documentation-only change and no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ba530b8f8832283777666b8ad5f09)